### PR TITLE
Improve makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,19 @@
-main: main.o utils.o
-	gcc -o main main.o utils.o
+CC = gcc
+CFLAGS = -std=c11 -O
+OBJS = main.o utils.o
 
-main.o: main.c
-	gcc -o main.o -c main.c
+all: pingyclash
+
+pingyclash: ${OBJS}
+	${CC} ${CFLAGS} -o $@ ${OBJS}
+
+main.o: main.c utils.h
+	${CC} ${CFLAGS} -o $@ -c $<
 
 utils.o: utils.c
-	gcc -o utils.o -c utils.c
+	${CC} ${CFLAGS} -o $@ -c $<
+
+clean:
+	rm -f pingyclash ${OBJS}
+
+.PHONY: all clean


### PR DESCRIPTION
The CC variable contains the compiler to use, CFLAGS contains compiler flags (I used -std=c11 which specifies the C standard, and -O which optimises the code), and OBJS contains the object files to link into the executable.

I changed the name of the "main" target to "pingyclash" because it's a better name than "main". I also changed some behavior in the targets to use some special variables. `$@` means the name of the target, and `$<` means the first dependency of the target. I also added an "all" target which is considered good practice, and a "clean" target you can use to remove all compiled code (you can use it if you wont to recompile).